### PR TITLE
Use caching feature of setup-python action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ on:
 env:
   PY_COLORS: 1
   ANSIBLE_FORCE_COLOR: 1
-  POETRY_VIRTUALENVS_PATH: ~/.cache/venv
-  POETRY_CACHE_DIR: ~/.cache/poetry
-  PIP_CACHE_DIR: ~/.cache/pip
 
 jobs:
 

--- a/.github/workflows/prepare-action/action.yml
+++ b/.github/workflows/prepare-action/action.yml
@@ -9,21 +9,16 @@ description: Install the necessary dependencies for jobs.
 runs:
   using: composite
   steps:
+    - name: Install poetry.
+      run: pipx install poetry
+      shell: bash
+
     - name: Set up Python 3.
       uses: actions/setup-python@v3
       id: setup-python
       with:
         python-version: '3.9'
-        
-    - name: Restore Python dependency cache.
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache
-        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('poetry.lock') }}
-
-    - name: Install poetry.
-      run: pip3 install poetry
-      shell: bash
+        cache: 'poetry'
 
     - name: Install dependencies via poetry.
       run: poetry install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ Group your changes into these categories:
 ### Changed
 
 * Implement full lint and test workflow via GitHub Actions
-  ([!1](https://github.com/hifis-net/ansible-role-gitlab-runner/pull/1)
+  ([\#1](https://github.com/hifis-net/ansible-role-gitlab-runner/pull/1)
+  by [tobiashuste](https://github.com/tobiashuste)).
+* Use the caching feature of the `setup-python` action
+  ([\#10](https://github.com/hifis-net/ansible-role-gitlab-runner/pull/10)
   by [tobiashuste](https://github.com/tobiashuste)).
 
 ## [0.5.1](https://gitlab.com/hifis/ansible/gitlab-ci-openstack/-/releases/v0.5.1) - 2022-03-17


### PR DESCRIPTION
It feels like caching has not worked properly before. Jobs are now running way faster.

* Ansible linting from around 2m 20s down to ~30s

The feature is documented here: https://github.com/actions/setup-python#caching-packages-dependencies