### PR TITLE
Skip runner registration in molecule test run

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -40,8 +40,8 @@ provisioner:
           gitlab_runner_concurrent: 4
     host_vars:
       instance_gitlab_ci_openstack_1:
-        gitlab_runner_version: "14.8.2~beta.1.g2ba60a95"
-        gitlab_runner_deb_file: "https://gitlab.com/hifis/gitlab-runner/-/package_files/31816472/download"
+        gitlab_runner_version: "14.9.1"
+        gitlab_runner_deb_file: "https://packages.gitlab.com/runner/gitlab-runner/packages/ubuntu/focal/gitlab-runner_14.9.1_amd64.deb/download.deb"
         gitlab_runner_install_docker: true
         gitlab_runner_ssh_public_key: "test_key.pub"
         gitlab_runner_ssh_private_key: "test_key"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -92,11 +92,17 @@
         that:
           - flatcar_linux_config.stdout.find(gitlab_runner_ssh_key) != -1
 
+    - name: Store registration token environment variable as Ansible fact.
+      ansible.builtin.set_fact:
+        gitlab_runner_registration_token: "{{ lookup('env', 'REGISTRATION_TOKEN') }}"
+
     - name: Assert that the runner was registered successfully
       ansible.builtin.command: gitlab-runner list
       changed_when: false
       register: runners
       failed_when: "'test01' not in runners.stderr"
+      # Do not verify runner registration in forks
+      when: "gitlab_runner_registration_token | length > 0"
 
     - name: Assert that the verify command is successful
       ansible.builtin.command: gitlab-runner verify
@@ -107,3 +113,5 @@
     - name: Unregister GitLab-Runner
       ansible.builtin.command: gitlab-runner unregister --all-runners
       changed_when: false
+      # Do not verify runner registration in forks
+      when: "gitlab_runner_registration_token | length > 0"

--- a/tasks/install.debianlike.yml
+++ b/tasks/install.debianlike.yml
@@ -53,10 +53,16 @@
         state: present
         update_cache: yes
 
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
 - name: Install gitlab-runner from a .deb file
   ansible.builtin.apt:
     deb: "{{ gitlab_runner_deb_file }}"
     allow_downgrade: yes
-  when: gitlab_runner_deb_file | length > 0
-
+  when:
+    - gitlab_runner_deb_file | length > 0
+    - "'gitlab-runner' not in ansible_facts.packages or
+      ansible_facts.packages['gitlab-runner'][0].version is version(gitlab_runner_version, 'ne')"
 ...


### PR DESCRIPTION
This makes sure that the CI pipeline works for forks as well. Therefore it does this:

* Skip runner registration verification in molecule test runs when the registration token is unset
* Do not redownload the `.deb` file if the expected version is already installed
* Download the `deb` file from `packages.gitlab.com`

Closes #9 