### PR TITLE
Add support for Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       matrix:
         distro:
           - ubuntu2004
+          - ubuntu2204
           - debian10
 
     steps:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ None.
 ### GitLab-Runner variables
 
 ```yaml
-gitlab_runner_version: 14.6.0
+gitlab_runner_version: 15.1.0
 ```
 
 The version of GitLab-Runner to install.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: "Ubuntu"
       versions:
         - "focal"
+        - "jammy"
     - name: "Debian"
       versions:
         - "buster"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,14 +12,14 @@ driver:
   name: docker
 platforms:
   - name: instance_gitlab_ci_openstack_1
-    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest
+    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2204}-ansible:latest
     pre_build_image: true
     privileged: true
     override_command: false
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: instance_gitlab_ci_openstack_2
-    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest
+    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2204}-ansible:latest
     pre_build_image: true
     privileged: true
     override_command: false
@@ -40,8 +40,8 @@ provisioner:
           gitlab_runner_concurrent: 4
     host_vars:
       instance_gitlab_ci_openstack_1:
-        gitlab_runner_version: "14.9.1"
-        gitlab_runner_deb_file: "https://packages.gitlab.com/runner/gitlab-runner/packages/ubuntu/focal/gitlab-runner_14.9.1_amd64.deb/download.deb"
+        gitlab_runner_version: "15.1.0"
+        gitlab_runner_deb_file: "https://packages.gitlab.com/runner/gitlab-runner/packages/ubuntu/jammy/gitlab-runner_15.1.0_amd64.deb/download.deb"
         gitlab_runner_install_docker: true
         gitlab_runner_ssh_public_key: "test_key.pub"
         gitlab_runner_ssh_private_key: "test_key"
@@ -58,7 +58,7 @@ provisioner:
             locked: True
             limit: 10
       instance_gitlab_ci_openstack_2:
-        gitlab_runner_version: "14.8.2"
+        gitlab_runner_version: "15.1.0"
         gitlab_runner_install_docker: false
         gitlab_runner_ssh_public_key: ""
         gitlab_runner_ssh_private_key: ""


### PR DESCRIPTION
This requires version 15.1.0 of gitlab-runner to be installed at least, which adds support for Ubuntu Jammy.

We can stick to one download URL since GitLab only provides one single deb package for all OS.

Closes #40 