### PR TITLE
Use template module instead of copy

### DIFF
--- a/tasks/separate-runner-configuration.yml
+++ b/tasks/separate-runner-configuration.yml
@@ -15,9 +15,9 @@
   changed_when: false
 
 - name: Copy isolated runner configuration
-  ansible.builtin.copy:
+  ansible.builtin.template:
+    src: "runner_config.j2"
     dest: "{{ tmp_runner_config_file.path }}"
-    content: "{{ runner_config }}"
     owner: "root"
     group: "root"
     mode: "0600"

--- a/templates/runner_config.j2
+++ b/templates/runner_config.j2
@@ -1,0 +1,7 @@
+{#
+# SPDX-FileCopyrightText: 2020 Helmholtz Centre for Environmental Research (UFZ)
+# SPDX-FileCopyrightText: 2020 Helmholtz-Zentrum Dresden - Rossendorf (HZDR)
+#
+# SPDX-License-Identifier: Apache-2.0
+#}
+{{ runner_config }}


### PR DESCRIPTION
According to the [documentation](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/copy_module.html#synopsis) using copy with variables can lead to unpredictable output. This is now also reflected in ansible-lint.
Compare with https://github.com/ansible/ansible-lint/blob/ac7284252d744318a446e3a4e9c788b923b767e7/src/ansiblelint/rules/template-instead-of-copy.md

The new rule is introduced in #65.