### PR TITLE
Lint folder molecule by molecule lint and fix linting violations

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -27,7 +27,7 @@ platforms:
     tty: true
 lint: |
   yamllint --strict --format colored .
-  ansible-lint -v --force-color --exclude .cache/ .
+  ansible-lint -v --force-color --exclude .cache/ . ./molecule
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -7,7 +7,8 @@
 - name: Prepare
   hosts: all
   tasks:
-    - when: ansible_os_family == 'Debian'
+    - name: Install necessary packages
+      when: ansible_os_family == 'Debian'
       block:
         - name: Install missing dependencies
           ansible.builtin.apt:
@@ -17,7 +18,8 @@
               - ca-certificates   # for Gitlab-Runner download
             state: present
             update_cache: yes
-    - when: ansible_distribution == 'Debian'
+    - name: Set up iptables
+      when: ansible_distribution == 'Debian'
       block:
         - name: "Install missing dependencies"
           ansible.builtin.apt:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -57,8 +57,8 @@
       register: ignition
       failed_when: not ignition.stat.isreg
 
-    # Determine generated SSH public key
-    - when: gitlab_runner_ssh_public_key | default("") | length == 0 or gitlab_runner_ssh_public_key | default("") | length == 0
+    - name: Determine generated SSH public key
+      when: gitlab_runner_ssh_public_key | default("") | length == 0 or gitlab_runner_ssh_public_key | default("") | length == 0
       block:
         - name: Assert that SSH key pair was created
           ansible.builtin.stat:


### PR DESCRIPTION
When providing `.` as the folder path of the lintables to `ansible-lint` it does not lint the folder `molecule/default` containing `converge.yml`, `prepare.yml`, `verify.yml`, hence folder `molecule/` is added to the `ansible-lint` call in the `molecule lint` commands.

Linting violations are fixed as well:

```
WARNING  Listing 3 violation(s) that are fatal
name[missing]: All tasks should be named.
molecule/default/prepare.yml:10 Task/Handler: block/always/rescue 

name[missing]: All tasks should be named.
molecule/default/prepare.yml:20 Task/Handler: block/always/rescue 

name[missing]: All tasks should be named.
molecule/default/verify.yml:61 Task/Handler: block/always/rescue 

 Rule Violation Summary              
 count tag           profile rule associated tags 
     3 name[missing] basic   idiom
```

Closes #105