### PR TITLE
Switch from ct to using butane

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,9 +18,9 @@ gitlab_runner_docker_machine_binary_url: "https://gitlab.com/gitlab-org/ci-cd/do
 
 gitlab_runner_docker_machine_binary_checksum: "sha256:dc92e2d2a293d66545eb0719d4816d5ebc7ac9ba5495823bbf4eb01c6da37a6e"
 
-gitlab_runner_transpiler_binary_url: https://github.com/flatcar-linux/container-linux-config-transpiler/releases/download/v0.9.3/ct-v0.9.3-x86_64-unknown-linux-gnu
+gitlab_runner_transpiler_binary_url: https://github.com/coreos/butane/releases/download/v0.16.0/butane-x86_64-unknown-linux-gnu
 
-gitlab_runner_transpiler_binary_checksum: "sha256:bb5ccbaddd26e0cfd241309de72ef3011aa718095bd2f94ca19096d98efb6ab8"
+gitlab_runner_transpiler_binary_checksum: "sha256:742bd941590688b61e64d252585cc532e22b868f9096b8b3714f752b2e7176eb"
 
 gitlab_runner_install_docker: true
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,7 +6,7 @@
 ---
 
 - name: "Transpile the flatcar linux configuration"
-  ansible.builtin.command: "ct -in-file /etc/gitlab-runner/flatcar-linux-config.yml -out-file /etc/gitlab-runner/ignition.json"
+  ansible.builtin.command: "butane -o /etc/gitlab-runner/ignition.json /etc/gitlab-runner/flatcar-linux-config.bu"
 
 - name: Restart GitLab-Runner
   ansible.builtin.service:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -83,7 +83,7 @@
         - gitlab_runner_ssh_private_key | default("") | length > 0
 
     - name: Read flatcar linux config
-      ansible.builtin.command: cat /etc/gitlab-runner/flatcar-linux-config.yml
+      ansible.builtin.command: cat /etc/gitlab-runner/ignition.json
       register: flatcar_linux_config
       changed_when: false
 

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -34,14 +34,14 @@
 - name: Download and install container-linux-config-transpiler
   ansible.builtin.get_url:
     url: "{{ gitlab_runner_transpiler_binary_url }}"
-    dest: /usr/local/bin/ct
+    dest: /usr/local/bin/butane
     mode: "0755"
     checksum: "{{ gitlab_runner_transpiler_binary_checksum }}"
 
 - name: Place the container linux configuration on the host
   ansible.builtin.template:
-    src: flatcar-linux-config.yml.j2
-    dest: /etc/gitlab-runner/flatcar-linux-config.yml
+    src: flatcar-linux-config.bu.j2
+    dest: /etc/gitlab-runner/flatcar-linux-config.bu
     owner: root
     group: root
     mode: 0644
@@ -73,7 +73,7 @@
       check_mode: no
 
     - name: "Dry-run of transpile the flatcar linux configuration"
-      ansible.builtin.command: "ct -in-file /etc/gitlab-runner/flatcar-linux-config.yml -out-file {{ (temp_directory.path, 'ignition.json') | path_join }}"
+      ansible.builtin.command: "butane -o {{ (temp_directory.path, 'ignition.json') | path_join }} /etc/gitlab-runner/flatcar-linux-config.bu"
       changed_when: false
       check_mode: no
 

--- a/templates/flatcar-linux-config.bu.j2
+++ b/templates/flatcar-linux-config.bu.j2
@@ -1,9 +1,11 @@
 {#
-# SPDX-FileCopyrightText: 2020 Helmholtz Centre for Environmental Research (UFZ)
-# SPDX-FileCopyrightText: 2020 Helmholtz-Zentrum Dresden - Rossendorf (HZDR)
+# SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
+# SPDX-FileCopyrightText: 2022 Helmholtz-Zentrum Dresden - Rossendorf (HZDR)
 #
 # SPDX-License-Identifier: Apache-2.0
 #}
+variant: flatcar
+version: 1.0.0
 passwd:
   users:
     - name: core
@@ -11,16 +13,14 @@ passwd:
         - {{ gitlab_runner_ssh_keypair.public_key }}
 storage:
   files:
-    - filesystem: root
-      path: /etc/resolv.conf
+    - path: /etc/resolv.conf
       mode: 0644
       contents:
         inline: |
 {% for nameserver in gitlab_runner_namerservers %}
           nameserver {{ nameserver }}
 {% endfor %}
-    - filesystem: root
-      path: /opt/docker/daemon.json
+    - path: /opt/docker/daemon.json
       mode: 0644
       contents:
         inline: |
@@ -32,10 +32,20 @@ storage:
 {% endif %}
             "mtu": {{ gitlab_runner_mtu }}
           }
-locksmith:
-  reboot_strategy: "off"
+    - path: /etc/flatcar/update.conf
+      contents:
+        inline: |
+                    REBOOT_STRATEGY=off
+      mode: 0420
 systemd:
   units:
+    - name: docker.service
+      enabled: true
+      dropins:
+        - name: 10-docker-opts.conf
+          contents: |
+            [Service]
+            Environment="DOCKER_OPTS=--mtu={{ gitlab_runner_mtu }}{% if gitlab_runner_registry_mirror is defined %} --registry-mirror={{ gitlab_runner_registry_mirror }}{% endif %}"
     - name: binfmt-init.service
       enabled: true
       contents: |
@@ -54,6 +64,3 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
-docker:
-  flags:
-    - --mtu={{ gitlab_runner_mtu }}


### PR DESCRIPTION
This change switched from ct to butane. ct is no longer maintained and replaced by butane.

* [Butane Documentation](https://coreos.github.io/butane/)
* [Flatcar Specification v1.0.0](https://coreos.github.io/butane/config-flatcar-v1_0/)
* [Flatcar Documentation](https://flatcar-linux.org/docs/latest/provisioning/config-transpiler/)

This should not result in a breaking change as the configuration is currently hardcoded in the Ansible file.

Closes #107 