### PR TITLE
Allow to define a list of registry mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ gitlab_runner_namerservers:
 The DNS nameservers to be used by the Openstack Flatcar virtual machine.
 
 ```yaml
+gitlab_runner_registry_mirrors:
+  - "https://registry-mirror-1.example"
+  - "https://registry-mirror-2.example"
+```
+
+(Optional) A list of Docker registry mirrors to be used.
+Takes precedence over the `gitlab_runner_registry_mirror` variable.
+
+```yaml
 gitlab_runner_registry_mirror: "https://registry-mirror.example"
 ```
 
@@ -287,7 +296,8 @@ to the list of your runner's `machine_options`.
 `gitlab_runner_mtu` needs to be set to the correct value.
 
 Also you can configure Docker-in-Docker to make use of a registry mirror by
-setting `gitlab_runner_registry_mirror` to the required value.
+setting `gitlab_runner_registry_mirrors` or`gitlab_runner_registry_mirror`
+to the required value.
 This is optional.
 
 To make this all work you finally need to mount a file in your runner volume

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -45,6 +45,9 @@ provisioner:
         gitlab_runner_install_docker: true
         gitlab_runner_ssh_public_key: "test_key.pub"
         gitlab_runner_ssh_private_key: "test_key"
+        gitlab_runner_registry_mirrors:
+          - "https://registry-mirror1.example"
+          - "https://registry-mirror2.example"
         gitlab_runner_list:
           - name: "test01"
             url: "https://gitlab.com"

--- a/templates/flatcar-linux-config.bu.j2
+++ b/templates/flatcar-linux-config.bu.j2
@@ -25,10 +25,14 @@ storage:
       contents:
         inline: |
           {
-{% if gitlab_runner_registry_mirror is defined %}
-            "registry-mirrors": [
-              "{{ gitlab_runner_registry_mirror }}"
-            ],
+{% set registry_mirrors_list = [] %}
+{% if gitlab_runner_registry_mirrors is defined %}
+  {% set registry_mirrors_list = gitlab_runner_registry_mirrors %}
+{% elif gitlab_runner_registry_mirror is defined %}
+  {% set registry_mirrors_list = [gitlab_runner_registry_mirror] %}
+{% endif %}
+{% if registry_mirrors_list | length > 0 %}
+            "registry-mirrors": {{ registry_mirrors_list | to_json }},
 {% endif %}
             "mtu": {{ gitlab_runner_mtu }}
           }
@@ -45,7 +49,7 @@ systemd:
         - name: 10-docker-opts.conf
           contents: |
             [Service]
-            Environment="DOCKER_OPTS=--mtu={{ gitlab_runner_mtu }}{% if gitlab_runner_registry_mirror is defined %} --registry-mirror={{ gitlab_runner_registry_mirror }}{% endif %}"
+            Environment="DOCKER_OPTS=--mtu={{ gitlab_runner_mtu }}{% if registry_mirrors_list | length > 0 %}{% for registry_mirror in registry_mirrors_list %} --registry-mirror={{ registry_mirror }}{% endfor %}{% endif %}"
     - name: binfmt-init.service
       enabled: true
       contents: |


### PR DESCRIPTION
In order to also support a list of registry mirrors this change introduces a new variable `gitlab_runner_registry_mirrors`. This variables will take precedence over `gitlab_runner_registry_mirror` if defined. The implementation is built in a way that it does not introduce a breaking change by supporting both the new and old variable.

We might decide to deprecate `gitlab_runner_registry_mirror` in a seperate change and remove it in a future release.