### PR TITLE
Download correct binaries for non x86_64 architectures

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,11 +14,11 @@ gitlab_gpg_key_id: "F6403F6544A38863DAA0B6E03F01618A51312F3F"
 
 gitlab_gpg_old_key_ids: []
 
-gitlab_runner_docker_machine_binary_url: "https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/releases/v0.16.2-gitlab.15/downloads/docker-machine-Linux-x86_64"
+gitlab_runner_docker_machine_binary_url: "https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/releases/v0.16.2-gitlab.15/downloads/docker-machine-Linux-{{ ansible_architecture }}"
 
 gitlab_runner_docker_machine_binary_checksum: "sha256:dc92e2d2a293d66545eb0719d4816d5ebc7ac9ba5495823bbf4eb01c6da37a6e"
 
-gitlab_runner_transpiler_binary_url: https://github.com/coreos/butane/releases/download/v0.16.0/butane-x86_64-unknown-linux-gnu
+gitlab_runner_transpiler_binary_url: "https://github.com/coreos/butane/releases/download/v0.16.0/butane-{{ ansible_architecture }}-unknown-linux-gnu"
 
 gitlab_runner_transpiler_binary_checksum: "sha256:742bd941590688b61e64d252585cc532e22b868f9096b8b3714f752b2e7176eb"
 


### PR DESCRIPTION
So far x86_64 was hardcoded. Thus the role failed on non x86_64 architectures. This change uses the ansible_architecture variable to download the correct binary.

Closes #121 