### PR TITLE
refactor: strip whitespaces before registry-mirrors in flatcar template

### DIFF
--- a/templates/flatcar-linux-config.bu.j2
+++ b/templates/flatcar-linux-config.bu.j2
@@ -28,9 +28,9 @@ storage:
           {
 {% set registry_mirrors_list = [] %}
 {% if gitlab_runner_registry_mirrors is defined %}
-  {% set registry_mirrors_list = gitlab_runner_registry_mirrors %}
+  {%- set registry_mirrors_list = gitlab_runner_registry_mirrors %}
 {% elif gitlab_runner_registry_mirror is defined %}
-  {% set registry_mirrors_list = [gitlab_runner_registry_mirror] %}
+  {%- set registry_mirrors_list = [gitlab_runner_registry_mirror] %}
 {% endif %}
 {% if registry_mirrors_list | length > 0 %}
             "registry-mirrors": {{ registry_mirrors_list | to_json }},


### PR DESCRIPTION
Before:
```yaml
    - path: /opt/docker/daemon.json
      mode: 0644
      contents:
        inline: |
          {
              "registry-mirrors": ["http://registry-mirror1.example", "https://registry-mirror2.example"],
            "insecure-registries": ["registry-mirror1.example"],
            "mtu": 1450
          }
```
After:
```yaml
    - path: /opt/docker/daemon.json
      mode: 0644
      contents:
        inline: |
          {
            "registry-mirrors": ["http://registry-mirror1.example", "https://registry-mirror2.example"],
            "insecure-registries": ["registry-mirror1.example"],
            "mtu": 1450
          }
```