### PR TITLE
feat: configure default-network-opts mtu

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,19 @@ this value.
 properly.
 
 ```yaml
+gitlab_runner_set_default_network_opts: false
+```
+
+This variable enables the declaration of
+[`default-network-opts`](https://docs.docker.com/engine/reference/commandline/dockerd/#default-network-options)
+in the Docker daemon configuration options.
+This helps to prevent docker-compose to create networks with an MTU of 1500,
+even though a lower MTU is required.
+With this change a user should not be required to set the MTU
+on their own in docker-compose files.
+Requires at least Docker 24.
+
+```yaml
 gitlab_runner_ssh_public_key: "./files/id_ed25519.pub"
 gitlab_runner_ssh_private_key: "./files/id_ed25519"
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,8 @@ gitlab_runner_namerservers:
 
 gitlab_runner_mtu: 1450
 
+gitlab_runner_set_default_network_opts: false
+
 gitlab_runner_config_path: "/etc/gitlab-runner/config.toml"
 
 gitlab_runner_listen_address: ""

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -73,6 +73,7 @@ provisioner:
         gitlab_runner_ssh_private_key: ""
         gitlab_runner_registry_mirror: "https://registry-mirror.example"
         gitlab_runner_listen_address: "127.0.0.1:9252"
+        gitlab_runner_set_default_network_opts: true
         gitlab_runner_list:
           - name: "test01"
             url: "https://gitlab.com"

--- a/templates/flatcar-linux-config.bu.j2
+++ b/templates/flatcar-linux-config.bu.j2
@@ -38,7 +38,14 @@ storage:
 {% if gitlab_runner_insecure_registries | length > 0 %}
             "insecure-registries": {{ gitlab_runner_insecure_registries | to_json }},
 {% endif %}
-            "mtu": {{ gitlab_runner_mtu }}
+            "mtu": {{ gitlab_runner_mtu }},
+{% if gitlab_runner_set_default_network_opts %}
+            "default-network-opts": {
+              "bridge": {
+                "com.docker.network.bridge.mtu": "{{ gitlab_runner_mtu }}"
+              }
+            }
+{% endif %}
           }
     - path: /etc/flatcar/update.conf
       overwrite: true
@@ -54,7 +61,7 @@ systemd:
         - name: 10-docker-opts.conf
           contents: |
             [Service]
-            Environment="DOCKER_OPTS=--mtu={{ gitlab_runner_mtu }}{% if registry_mirrors_list | length > 0 %}{% for registry_mirror in registry_mirrors_list %} --registry-mirror={{ registry_mirror }}{% endfor %}{% endif %}"
+            Environment="DOCKER_OPTS=--mtu={{ gitlab_runner_mtu }} {% if gitlab_runner_set_default_network_opts %}--default-network-opt bridge=com.docker.network.bridge.mtu={{ gitlab_runner_mtu }}{% endif %}{% if registry_mirrors_list | length > 0 %}{% for registry_mirror in registry_mirrors_list %} --registry-mirror={{ registry_mirror }}{% endfor %}{% endif %}"
     - name: binfmt-init.service
       enabled: true
       contents: |


### PR DESCRIPTION
If an MTU lower than 1500 is present, docker-compose inside CI jobs can lead to issues as docker-compose always defaults to networks with an MTU of 1500. With this change a user should not be required to set the MTU on their own in docker-compose.
Requires at least Docker 24.