### PR TITLE
Update Butane to version 0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ The checksum of the downloaded docker-machine binary. This must correspond to th
 ### Flatcar Linux configuration
 
 ```yaml
-gitlab_runner_transpiler_binary_url: "https://github.com/coreos/butane/releases/download/v0.17.0/butane-{{ ansible_architecture }}-unknown-linux-gnu"
+gitlab_runner_transpiler_binary_url: "https://github.com/coreos/butane/releases/download/v0.20.0/butane-{{ ansible_architecture }}-unknown-linux-gnu"
 ```
 
 The URL to the configuration transpiler binary that shall be used.
 
 ```yaml
-gitlab_runner_transpiler_binary_checksum: "sha256:ce0df25ade8a9b5f570636281897479af06894d9f2e10aa07ae211231503ce1d"
+gitlab_runner_transpiler_binary_checksum: "sha256:28003c61b991d17d66c23cd3f305202ae14736b8e7fd941986b6086cf931ed4b"
 ```
 
 The checksum of the download transpiler binary. This must correspond to the file

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,9 +20,9 @@ gitlab_runner_docker_machine_binary_url: "https://gitlab.com/gitlab-org/ci-cd/do
 
 gitlab_runner_docker_machine_binary_checksum: "sha256:04cc18c8f6ee0d71614064fa81116f20f3a37af53eeebf19bfb832ab9c46d3a0"
 
-gitlab_runner_transpiler_binary_url: "https://github.com/coreos/butane/releases/download/v0.19.0/butane-{{ ansible_architecture }}-unknown-linux-gnu"
+gitlab_runner_transpiler_binary_url: "https://github.com/coreos/butane/releases/download/v0.20.0/butane-{{ ansible_architecture }}-unknown-linux-gnu"
 
-gitlab_runner_transpiler_binary_checksum: "sha256:a3a17c66652c0cf2cbccfa84f092737b3775e5345800277960fd259bbc66061a"
+gitlab_runner_transpiler_binary_checksum: "sha256:28003c61b991d17d66c23cd3f305202ae14736b8e7fd941986b6086cf931ed4b"
 
 gitlab_runner_install_docker: true
 


### PR DESCRIPTION
* [Release Notes](https://github.com/coreos/butane/releases/tag/v0.20.0)
* [Full changelog](https://github.com/coreos/butane/compare/v0.19.0...v0.20.0)