### PR TITLE
Beta: implement autoscaling using new autoscaler method

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,102 @@ configuration by adding
 
 to the list of configured `volumes`.
 
+### Beta: GitLab-Runner Autoscaling
+
+GitLab-Runner Autoscaling is the future way of implementing autoscaling on
+cloud infrastructures.
+This is the successor to the autoscaling technology based on Docker Machine,
+which is deprecated and will no longer be supported through the course of 2025.
+The new beta feature implements support for the new method in Openstack.
+
+#### Variables
+
+It is important to set these variables. Otherwise the role execution will fail.
+
+```yaml
+gitlab_runner_autoscaler_plugin_url: "https://down.load/fleeting-plugin-openstack-binary"
+```
+
+The URL where to download the autoscaler plugin binary from.
+
+```yaml
+gitlab_runner_autoscaler_plugin_checksum: "sha256:..."
+```
+
+The checksum of the autoscaler plugin binary file.
+
+```yaml
+gitlab_runner_autoscaler_openstack_auth_url: "https://openstack.example:5000/v3"
+```
+
+The Openstack authentication URL of Keystone.
+
+```yaml
+gitlab_runner_autoscaler_openstack_username: "gitlab-runner"
+```
+
+The username of the Openstack user to interact with the API.
+
+```yaml
+gitlab_runner_autoscaler_openstack_password: "123456"
+```
+
+The corresponding password of the user.
+
+```yaml
+gitlab_runner_autoscaler_openstack_project_id: "project_id"
+```
+
+Specify the project id in Openstack.
+
+```yaml
+gitlab_runner_autoscaler_openstack_user_domain_name: "Default"
+```
+
+Domain name of the user authenticating with Openstack.
+
+```yaml
+gitlab_runner_autoscaler_openstack_region_name: "RegionOne"
+```
+
+Region name of the Openstack cluster.
+
+#### Example configuration
+
+```yaml
+gitlab_runner_list:
+  - name: "Test Runner"
+    url: "https://gitlab.com"
+    description: "Autoscale Runner for Openstack"
+    limit: 0
+    authentication_token: "{{ gitlab_runner_authentication_token }}"
+    executor: "docker-autoscaler"
+    environment: "test"
+    docker_image: "ubuntu:latest"
+    docker_disable_cache: True
+    docker_volumes: ["/tmp/certs:/certs", "/opt/docker/daemon.json:/etc/docker/daemon.json:ro"]
+    docker_shm_size: 2147483648
+    docker_privileged: true
+    docker_network_mtu: "{{ gitlab_runner_mtu }}"
+    locked: false
+    tags: "{{ gitlab_runner_tags | default([]) }}"
+    run_untagged: "{{ gitlab_runner_run_untagged | default(false) }}"
+    cache_insecure: "false"
+    autoscaler_max_builds: 1
+    autoscaler_idle_count: 4
+    autoscaler_max_instances: "10"
+    autoscaler_group_name: "autoscaler-runners"
+    autoscaler_cloud_name: "openstack"
+    autoscaler_clouds_config: "/etc/gitlab-runner/clouds.yaml"
+    autoscaler_flavor_ref: "5be35abe-a4d5-427f-a0f8-c7afe19961e2"
+    autoscaler_image_ref: "8225b31c-86fc-4e48-a3e4-8bf800d5fc8d"
+    autoscaler_network_id: "ea80dd07-5dc2-4f18-af04-733ace5892ef"
+    autoscaler_security_group: "c693de06-7dba-4694-9fd6-1b785904eff3"
+    autoscaler_scheduler_hint: "c98090ea-6893-4810-b066-5c3f34038c2a"
+    autoscaler_username: "core"
+    autoscaler_keyname: "runner-internal"
+```
+
 ## Dependencies
 
 GitLab-Runner for Openstack depends on `docker-machine` requiring docker to be available on the system.

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -37,6 +37,7 @@
       ansible.builtin.command: docker-machine version
       changed_when: false
       register: machine_version
+      when: "gitlab_runner_list | selectattr('executor', 'equalto', 'docker+machine') | list | length > 0"
       failed_when: "'0.16.2-gitlab.25' not in machine_version.stdout"
 
     - name: Assert that Gitlab-Runner is installed

--- a/tasks/install.autoscaler-plugin.yml
+++ b/tasks/install.autoscaler-plugin.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Helmholtz-Zentrum Dresden - Rossendorf (HZDR)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: "Download and install autoscaler plugin"
+  ansible.builtin.get_url:
+    url: "{{ gitlab_runner_autoscaler_plugin_url }}"
+    dest: "/usr/local/bin/fleeting-plugin-openstack"
+    checksum: "{{ gitlab_runner_autoscaler_plugin_checksum }}"
+    mode: '0755'
+    owner: "root"
+    group: "root"
+
+- name: "Place clouds.yaml template"
+  ansible.builtin.template:
+    src: "clouds.yaml.j2"
+    dest: "/etc/gitlab-runner/clouds.yaml"
+    owner: "root"
+    group: "root"
+    mode: '0600'
+  no_log: true
+
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,11 @@
 - name: "Set OS family dependent variables"
   ansible.builtin.include_vars: "{{ ansible_os_family | lower }}.yml"
 
+- name: "Set variable if autoscaling runner must be configured"
+  ansible.builtin.set_fact:
+    gitlab_runner_install_docker_machine: "{{ gitlab_runner_list | selectattr('executor', 'equalto', 'docker+machine') | list | length > 0 }}"
+    gitlab_runner_install_autoscaler: "{{ gitlab_runner_list | selectattr('executor', 'equalto', 'docker-autoscaler') | list | length > 0 }}"
+
 - name: "Check if directory /etc/gitlab-runner already exists"
   ansible.builtin.stat:
     path: "/etc/gitlab-runner"
@@ -18,10 +23,15 @@
 
 - name: "Include docker-machine tasks"
   ansible.builtin.include_tasks: install.docker-machine.yml
+  when: "gitlab_runner_install_docker_machine"
 
 - name: "Include installation tasks for Debian-like OS"
   ansible.builtin.include_tasks: install.debianlike.yml
   when: ansible_os_family == "Debian"
+
+- name: "Include autoscaler install tasks"
+  ansible.builtin.include_tasks: install.autoscaler-plugin.yml
+  when: "gitlab_runner_install_autoscaler"
 
 - name: "Include tasks to configure the system"
   ansible.builtin.include_tasks: configuration.yml
@@ -31,12 +41,17 @@
 
 - name: "Initialize docker-machine"
   ansible.builtin.include_tasks: "docker-machine-init.yml"
-  when:
-    - "gitlab_runner.executor == 'docker+machine'"
+  when: "gitlab_runner_install_docker_machine"
   no_log: true
   loop: "{{ gitlab_runner_list }}"
   loop_control:
     loop_var: gitlab_runner
+
+- name: "Slurp ignition json"
+  ansible.builtin.slurp:
+    src: "/etc/gitlab-runner/ignition.json"
+  register: "ignition_json"
+  when: "gitlab_runner_install_autoscaler"
 
 - name: "Template config file"
   ansible.builtin.template:
@@ -47,6 +62,8 @@
     mode: "0600"
   notify: "Restart GitLab-Runner"
   no_log: true
+  vars:
+    ignition_content: "{{ ignition_json['content'] | b64decode }}"
 
 - name: "Start GitLab-Runner"
   ansible.builtin.service:

--- a/templates/clouds.yaml.j2
+++ b/templates/clouds.yaml.j2
@@ -1,0 +1,17 @@
+{#
+# SPDX-FileCopyrightText: Helmholtz-Zentrum Dresden - Rossendorf (HZDR)
+#
+# SPDX-License-Identifier: Apache-2.0
+#}
+clouds:
+  openstack:
+    auth:
+      auth_url: "{{ gitlab_runner_autoscaler_openstack_auth_url }}"
+      username: "{{ gitlab_runner_autoscaler_openstack_username }}"
+      password: "{{ gitlab_runner_autoscaler_openstack_password }}"
+      project_id: "{{ gitlab_runner_autoscaler_openstack_project_id }}"
+      project_name: "{{ gitlab_runner_autoscaler_openstack_project_name }}"
+      user_domain_name:  "{{ gitlab_runner_autoscaler_openstack_user_domain_name }}"
+    region_name: "{{ gitlab_runner_autoscaler_openstack_region_name }}"
+    interface: "public"
+    identity_api_version: 3

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -87,4 +87,40 @@ sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"
     MachineName = "{{ runner.machine_name }}"
     MachineOptions = {{ runner.machine_options | default([]) | to_json }}
 {% endif %}
+{% if runner.executor == "docker-autoscaler" %}
+  [runners.autoscaler]
+    capacity_per_instance = 1
+    max_use_count = {{ runner.autoscaler_max_builds | default(0) }}
+    max_instances = {{ runner.autoscaler_max_instances }}
+    plugin = "fleeting-plugin-openstack"
+
+  [runners.autoscaler.plugin_config]
+    cloud = "{{ runner.autoscaler_cloud_name }}"
+    clouds_config = "{{ runner.autoscaler_clouds_config }}"
+    name = "{{ runner.autoscaler_group_name | default('autoscaler-runners') }}"
+    boot_time = "3m"
+
+  [runners.autoscaler.plugin_config.server_spec]
+    name = "autoscaler-%d"
+    description = "{{ runner.description }}"
+    tags = [ "gitlab-ci" ]
+    imageRef = "{{ runner.autoscaler_image_ref }}"
+    flavorRef = "{{ runner.autoscaler_flavor_ref }}"
+    key_name = "{{ runner.autoscaler_keyname }}"
+    networks = [ { uuid = "{{ runner.autoscaler_network_id }}" } ]
+    security_groups = [ "{{ runner.autoscaler_security_group }}" ]
+    scheduler_hints = { group = "{{ runner.autoscaler_scheduler_hint }}" }
+    user_data = '{{ ignition_content | to_json }}'
+
+  [runners.autoscaler.connector_config]
+    username = "{{ runner.autoscaler_username }}"
+    key_path = "{{ gitlab_runner_ssh_private_key_path }}"
+    use_static_credentials = true
+    keepalive = "30s"
+    timeout = "0m"
+    use_external_addr = false
+
+  [[runners.autoscaler.policy]]
+    idle_count = {{ runner.autoscaler_idle_count | default(0) }}
+{% endif %}
 {% endfor %}

--- a/templates/flatcar-linux-config.bu.j2
+++ b/templates/flatcar-linux-config.bu.j2
@@ -61,7 +61,7 @@ systemd:
         - name: 10-docker-opts.conf
           contents: |
             [Service]
-            Environment="DOCKER_OPTS=--mtu={{ gitlab_runner_mtu }} {% if gitlab_runner_set_default_network_opts %}--default-network-opt bridge=com.docker.network.bridge.mtu={{ gitlab_runner_mtu }}{% endif %}{% if registry_mirrors_list | length > 0 %}{% for registry_mirror in registry_mirrors_list %} --registry-mirror={{ registry_mirror }}{% endfor %}{% endif %}"
+            Environment="DOCKER_OPTS=--mtu={{ gitlab_runner_mtu }} {% if gitlab_runner_set_default_network_opts %}--default-network-opt bridge=com.docker.network.bridge.mtu={{ gitlab_runner_mtu }}{% endif %}{% if registry_mirrors_list | length > 0 %}{% for registry_mirror in registry_mirrors_list %} --registry-mirror={{ registry_mirror }}{% endfor %}{% endif %}{% if gitlab_runner_insecure_registries | length > 0 %}{% for insecure_registry in gitlab_runner_insecure_registries %} --insecure-registry={{ insecure_registry }}{% endfor %}{% endif %}"
     - name: binfmt-init.service
       enabled: true
       contents: |


### PR DESCRIPTION
* Implements everything that is needed to configure autoscaling using the new method provided by GitLab: https://docs.gitlab.com/runner/runner_autoscale/ and https://docs.gitlab.com/runner/executors/docker_autoscaler.html
* Supports only Openstack so far
* Aims to replace docker-machine in the future