### PR TITLE
Require at least ansible-core 2.15

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   company: "Helmholtz Association"
   issue_tracker_url: "https://github.com/hifis-net/ansible-role-gitlab-runner/issues"
   license: "Apache-2.0"
-  min_ansible_version: "2.13"
+  min_ansible_version: "2.15"
 
   platforms:
     - name: "Ubuntu"


### PR DESCRIPTION
`ansible.builtin.deb822_repository` is only available in ansible-core `2.15` and newer. ansible-core `2.14` is end of life.

See https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix

Closes #257 